### PR TITLE
Fix arbitrary waveform features

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ For now, the following features are supported:
 - Configuring noise function bandwidth;
 - Configuring arbitrary waveform samples file and sample rate.
 - Loading arbitrary waveform file from array of points.
+- Storing loaded arbitrary waveform into non-volatile memory

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Agilent 33521A EPICS IOC
-========================
+# Agilent 33521A EPICS IOC
 
 This is an EPICS IOC for the Agilent 33521A 30MHz Function/Arbitrary Waveform
 Generator.
@@ -66,3 +65,4 @@ For now, the following features are supported:
 - Configuring pseudo-random bit stream bit rate, edge time and sequence type;
 - Configuring noise function bandwidth;
 - Configuring arbitrary waveform samples file and sample rate.
+- Loading arbitrary waveform file from array of points.

--- a/agilent33521aApp/Db/agilent33521a.db
+++ b/agilent33521aApp/Db/agilent33521a.db
@@ -496,10 +496,12 @@ record(waveform, "$(P)$(R)ArbitraryWfmFile-SP") {
     field(FLNK, "$(P)$(R)ArbitraryWfmFile-RB")
 }
 
+# For this function, the expected usage is "caput <PV> <numberOfPoints+1> <filename> <value1> <value2> <value3> ..."
+# The protocol file will send data in a comma separated list, as specified from the device's manual
 record(waveform, "$(P)$(R)ArbitraryLoadWfmData-Cmd") {
     field(DESC, "Load arbitrary waveform data into memory")
     field(NELM, 4096)
-    field(FTVL, "CHAR")
+    field(FTVL, "STRING")
     field(DTYP, "stream")
     field(INP, "@agilent33521a.proto loadArbitraryWaveformData $(PORT)")
 }

--- a/agilent33521aApp/Db/agilent33521a.db
+++ b/agilent33521aApp/Db/agilent33521a.db
@@ -476,31 +476,38 @@ record(stringin, "$(P)$(R)ArbitraryWfmFile-RB") {
     field(INP, "@agilent33521a.proto getArbitraryWaveformFile $(PORT)")
 }
 
+# Loads files stored in EEPROM or EXT. MEM. for them to be used. 
+# For full paths, single quotes are needed in caput command. Path backslashes need to be escaped:
+# Example: caput <PV> 'INT:\\BUILTIN\\CARDIAC.arb' would make this arb available for usage.
 record(stringout, "$(P)$(R)ArbitraryLoadWfmFile-Cmd") {
     field(DESC, "Load arbitrary waveform file into memory")
     field(DTYP, "stream")
     field(OUT, "@agilent33521a.proto loadArbitraryWaveformFile $(PORT)")
 }
 
-# For full paths, double quotes are needed in caget command. Path backslashes need to be escaped:
-# caput <PV> "INT:\\\BUILTIN\\\EXP_RISE.arb"
-# For files stored in root directory, double quotes are not needed:
-# caput <PV> myfile
 record(stringout, "$(P)$(R)ArbitraryWfmFile-SP") {
-    field(DESC, "Set arbitrary waveform file path")
+    field(DESC, "Select arbitrary waveform file from path")
+    field(PINI, "YES")
     field(DTYP, "stream")
     field(OUT, "@agilent33521a.proto setArbitraryWaveformFile $(PORT)")
     field(FLNK, "$(P)$(R)ArbitraryWfmFile-RB")
 }
 
-# For this function, the expected usage is "caput <PV> <numberOfPoints+1> <filename> <value1> <value2> <value3> ..."
+# For this PV, the expected usage is "caput <PV> <numberOfPoints+1> <filename> <value1> <value2> <value3> ..."
 # The protocol file will send data in a comma separated list, as specified from the device's manual
 record(waveform, "$(P)$(R)ArbitraryLoadWfmData-Cmd") {
-    field(DESC, "Load arbitrary waveform data into memory")
+    field(DESC, "Load arbitrary waveform data from array")
     field(NELM, 4096)
     field(FTVL, "STRING")
     field(DTYP, "stream")
     field(INP, "@agilent33521a.proto loadArbitraryWaveformData $(PORT)")
+}
+
+# For this PV, the full path to be stored need to be provided: "caput <PV> 'INT:\\mywfm.arb'"
+record(stringout, "$(P)$(R)ArbitraryStoreWfmFile-Cmd") {
+    field(DESC, "Store current waveform file into non-volatile mem.")
+    field(DTYP, "stream")
+    field(OUT, "@agilent33521a.proto storeArbitraryWaveformFile $(PORT)")
 }
 
 record(bo, "$(P)$(R)ClearMemory-Cmd") {

--- a/agilent33521aApp/Db/agilent33521a.db
+++ b/agilent33521aApp/Db/agilent33521a.db
@@ -470,29 +470,26 @@ record(ao, "$(P)$(R)ArbitrarySplRate-SP") {
     field(FLNK, "$(P)$(R)ArbitrarySplRate-RB")
 }
 
-record(waveform, "$(P)$(R)ArbitraryWfmFile-RB") {
+record(stringin, "$(P)$(R)ArbitraryWfmFile-RB") {
     field(DESC, "Read arbitrary waveform file path")
-    field(NELM, 240)
-    field(FTVL, "STRING")
     field(DTYP, "stream")
     field(INP, "@agilent33521a.proto getArbitraryWaveformFile $(PORT)")
 }
 
-record(waveform, "$(P)$(R)ArbitraryLoadWfmFile-Cmd") {
+record(stringout, "$(P)$(R)ArbitraryLoadWfmFile-Cmd") {
     field(DESC, "Load arbitrary waveform file into memory")
-    field(NELM, 240)
-    field(FTVL, "STRING")
     field(DTYP, "stream")
-    field(INP, "@agilent33521a.proto loadArbitraryWaveformFile $(PORT)")
+    field(OUT, "@agilent33521a.proto loadArbitraryWaveformFile $(PORT)")
 }
 
-record(waveform, "$(P)$(R)ArbitraryWfmFile-SP") {
+# For full paths, double quotes are needed in caget command. Path backslashes need to be escaped:
+# caput <PV> "INT:\\\BUILTIN\\\EXP_RISE.arb"
+# For files stored in root directory, double quotes are not needed:
+# caput <PV> myfile
+record(stringout, "$(P)$(R)ArbitraryWfmFile-SP") {
     field(DESC, "Set arbitrary waveform file path")
-    field(PINI, "YES")
-    field(NELM, 240)
-    field(FTVL, "STRING")
     field(DTYP, "stream")
-    field(INP, "@agilent33521a.proto setArbitraryWaveformFile $(PORT)")
+    field(OUT, "@agilent33521a.proto setArbitraryWaveformFile $(PORT)")
     field(FLNK, "$(P)$(R)ArbitraryWfmFile-RB")
 }
 

--- a/agilent33521aApp/Db/agilent33521a.proto
+++ b/agilent33521aApp/Db/agilent33521a.proto
@@ -248,6 +248,7 @@ setArbitraryWaveformFile {
 }
 
 loadArbitraryWaveformData {
+    separator=",";
     out "SOURce1:DATA:ARBitrary %s"
 }
 

--- a/agilent33521aApp/Db/agilent33521a.proto
+++ b/agilent33521aApp/Db/agilent33521a.proto
@@ -1,4 +1,4 @@
-TERMINATOR = NL;
+terminator = NL;
 ExtraInput = Ignore;
 ReplyTimeout = 1000;
 
@@ -233,9 +233,10 @@ setArbitraryWaveformSampleRate {
     @init { getArbitraryWaveformSampleRate }
 }
 
+#Depends on PCRE support - check https://paulscherrerinstitute.github.io/StreamDevice/formats.html#regex
 getArbitraryWaveformFile {
     out "SOURce1:FUNCtion:ARBitrary?";
-    in "%.1/\"([^\"]*)\"/"
+    in "\"%[A-Z-0-9\\-_./a-z]\"";
 }
 
 loadArbitraryWaveformFile {

--- a/agilent33521aApp/Db/agilent33521a.proto
+++ b/agilent33521aApp/Db/agilent33521a.proto
@@ -233,7 +233,6 @@ setArbitraryWaveformSampleRate {
     @init { getArbitraryWaveformSampleRate }
 }
 
-#Depends on PCRE support - check https://paulscherrerinstitute.github.io/StreamDevice/formats.html#regex
 getArbitraryWaveformFile {
     out "SOURce1:FUNCtion:ARBitrary?";
     in "\"%[A-Z-0-9\\-_./a-z]\"";
@@ -251,6 +250,10 @@ setArbitraryWaveformFile {
 loadArbitraryWaveformData {
     separator=",";
     out "SOURce1:DATA:ARBitrary %s"
+}
+
+storeArbitraryWaveformFile {
+    out "MMEMory:STOR:DATA1 \"%s\"";
 }
 
 clearMemory {


### PR DESCRIPTION
- Fixed arbitrary waveform loading from array of points (ArbitraryLoadWfmData-Cmd);
- Fixed arbitrary waveform file related PVs: ArbitraryWfmFile-RB, ArbitraryLoadWfmFile-Cmd and ArbitraryWfmFile-SP
- Included new PV for storing arbitrary waveforms into non-volatile memory: ArbitraryStoreWfmFile-Cmd 